### PR TITLE
Basic support for credentialed CORS requests

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -69,7 +69,17 @@ var createApi = function(recipes, connections, channels) {
 
     var knownOptions = {
       string: 'port',
-      default: {port: process.env.PORT || 3000}
+      boolean: 'cors.enabled',
+      boolean: 'cors.origin',
+      boolean: 'cors.credentials',
+      default: {
+        port: process.env.PORT || 3000,
+        cors: {
+          enabled: process.env.CORS_ENABLED || false,
+          origin: process.env.CORS_ORIGIN || false,
+          credentials: process.env.CORS_CREDENTIALS || false
+        }
+      }
     };
     var options = minimist(process.argv.slice(2), knownOptions);
     var app = server(options);

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,7 +3,14 @@ module.exports = function(options) {
   var cors = require('cors');
   var app = express();
 
-  app.use(cors());
+  if (process.env.CORS_ENABLED) {
+    var options = {
+      origin: process.env.CORS_ORIGIN || false,
+      credentials: process.env.CORS_CREDENTIALS || false
+    };
+
+    app.use(cors(options));
+  }
 
   var server = app.listen(options.port, function() {
     var host = server.address().address;

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,13 +3,8 @@ module.exports = function(options) {
   var cors = require('cors');
   var app = express();
 
-  if (process.env.CORS_ENABLED) {
-    var options = {
-      origin: process.env.CORS_ORIGIN || false,
-      credentials: process.env.CORS_CREDENTIALS || false
-    };
-
-    app.use(cors(options));
+  if (options.cors.enabled) {
+    app.use(cors({ origin: options.cors.origin, credentials: options.cors.credentials }));
   }
 
   var server = app.listen(options.port, function() {

--- a/test/channels/api.js
+++ b/test/channels/api.js
@@ -34,4 +34,50 @@ describe('api', function() {
     .expect(200, {hello: 'there'}, done)
     ;
   });
+
+  describe('cors', function() {
+    it('does not return a CORS header by default', function(done) {
+      request
+      .get('/file')
+      .set('Origin', 'localhost')
+      .expect((res) => { if ('access-control-allow-origin' in res.headers) throw new Error; })
+      .end(done)
+      ;
+    });
+
+    // TODO: Work out how best to test these cases which rely on environment variables.
+
+    xit('returns a wildcard CORS header', function(done) {
+      // Set CORS_ENABLED
+
+      request
+      .get('/file')
+      .set('Origin', 'localhost')
+      .expect('Access-Control-Allow-Origin', '*')
+      .end(done)
+      ;
+    });
+
+    xit('returns an origin-mirroring CORS header', function(done) {
+      // Set CORS_ORIGIN
+
+      request
+      .get('/file')
+      .set('Origin', 'localhost')
+      .expect('Access-Control-Allow-Origin', 'localhost')
+      .end(done)
+      ;
+    });
+
+    xit('returns a credentials CORS header', function(done) {
+      // Set CORS_CREDENTIALS
+
+      request
+      .get('/file')
+      .set('Origin', 'localhost')
+      .expect('Access-Control-Allow-Credentials', 'true')
+      .end(done)
+      ;
+    });
+  });
 });


### PR DESCRIPTION
The following line provides support for browser-based clients making credentialed CORS requests (ie. those requests containing `Access-Control-Allow-Credentials: true`).

This could be an option, as there is some downside to leaving it on by default (increased chance of XSS by attackers messing with cookies).